### PR TITLE
Use Upstart for broker init

### DIFF
--- a/manifests/broker/service.pp
+++ b/manifests/broker/service.pp
@@ -13,10 +13,15 @@ class kafka::broker::service {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  file { '/etc/init.d/kafka':
-    ensure  => present,
-    mode    => '0755',
-    content => template('kafka/init.erb')
+  file {
+      'kafka-upstart':
+        path    => '/etc/init/kafka.conf',
+        mode    => '0644',
+        content => template('kafka/upstart.erb');
+      'kafka-init-helper':
+        ensure => 'link',
+        path   => '/etc/init.d/kafka',
+        target => $common::upstart_helper;
   }
 
   service { 'kafka':
@@ -24,7 +29,7 @@ class kafka::broker::service {
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
-    require    => File['/etc/init.d/kafka']
+    require    => File['kafka-upstart']
   }
 
 }

--- a/templates/upstart.erb
+++ b/templates/upstart.erb
@@ -1,0 +1,24 @@
+# Kafka server
+description  "Kafka Server"
+
+start on filesystem runlevel [2345]
+stop on runlevel [!2345]
+respawn
+respawn limit 10 5
+umask 022
+
+kill timeout 30
+
+env NAME=kafka
+env PID_FILE=/var/run/$NAME.pid
+env DAEMON="/opt/kafka/bin/kafka-server-start.sh"
+env DAEMON_OPTS="/opt/kafka/config/server.properties"
+env KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9990"
+
+script
+    /sbin/start-stop-daemon --start --make-pidfile --pidfile $PID_FILE --exec $DAEMON $DAEMON_OPTS  >> /var/log/kafka/server.log 2>&1
+end script
+
+pre-stop script
+  /sbin/start-stop-daemon --stop --pidfile $PID_FILE --exec $DAEMON $DAEMON  >> /var/log/kafka/server.log 2>&1
+end script


### PR DESCRIPTION
Move the broker init to upstart, because the init script has some issues when restarting due to a config change.
